### PR TITLE
Add v1 events ingestion and listing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Memplane is being built to serve that role for ecosystems such as LangChain and 
 
 ## Project Status
 
-Current phase: bootstrap and service foundation.
+Current phase: episodic event primitives and initial API.
 
 ## Quick Start
 
@@ -32,15 +32,29 @@ Health check:
 curl -i http://127.0.0.1:8080/health
 ```
 
+Create event:
+
+```bash
+curl -i -X POST http://127.0.0.1:8080/v1/events \
+  -H 'Content-Type: application/json' \
+  -d '{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":0,"end_token_exclusive":10,"created_at":"2026-02-10T12:00:00Z"}'
+```
+
+List session events:
+
+```bash
+curl -i "http://127.0.0.1:8080/v1/events?tenant_id=tenant_1&session_id=session_1"
+```
+
 ## Roadmap
 
 1. Service foundation (done)
-2. Core episodic event model
-3. In-memory event store
-4. Surprise-based boundary detection (paper-aligned)
-5. Boundary refinement (paper-aligned)
-6. Two-stage retrieval: similarity + contiguity buffers
-7. Public API for ingest/retrieve/session lifecycle
+2. Core episodic event model (done)
+3. In-memory event store (done)
+4. Initial ingest/list API (done)
+5. Surprise-based boundary detection (paper-aligned)
+6. Boundary refinement (paper-aligned)
+7. Two-stage retrieval: similarity + contiguity buffers
 8. Durable persistence
 9. LangChain and Mastra adapters
 10. Evaluation harness and production hardening

--- a/cmd/memplane/main.go
+++ b/cmd/memplane/main.go
@@ -12,6 +12,7 @@ import (
 	"memplane/internal/config"
 	"memplane/internal/httpserver"
 	"memplane/internal/logging"
+	"memplane/internal/memory"
 
 	"go.uber.org/zap"
 )
@@ -29,13 +30,17 @@ func run() error {
 		return err
 	}
 
+	httpserver.EnableStrictJSONDecoding()
+
 	logger, err := logging.New(cfg.Environment, cfg.LogLevel)
 	if err != nil {
 		return err
 	}
 	defer logger.Sync()
 
-	router, err := httpserver.NewRouter(cfg.Environment)
+	store := memory.NewStore()
+
+	router, err := httpserver.NewRouter(cfg.Environment, store)
 	if err != nil {
 		return err
 	}

--- a/internal/httpserver/events.go
+++ b/internal/httpserver/events.go
@@ -1,0 +1,63 @@
+package httpserver
+
+import (
+	"errors"
+	"net/http"
+
+	"memplane/internal/memory"
+
+	"github.com/gin-gonic/gin"
+)
+
+type eventsHandler struct {
+	store *memory.Store
+}
+
+type listEventsRequest struct {
+	TenantID  string `form:"tenant_id" binding:"required"`
+	SessionID string `form:"session_id" binding:"required"`
+}
+
+const maxCreateEventBodyBytes int64 = 1 << 20
+
+func newEventsHandler(store *memory.Store) eventsHandler {
+	return eventsHandler{store: store}
+}
+
+func (h eventsHandler) create(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxCreateEventBodyBytes)
+
+	var event memory.Event
+	if err := c.ShouldBindJSON(&event); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	event.CreatedAt = event.CreatedAt.UTC()
+
+	if err := h.store.Append(event); err != nil {
+		if errors.Is(err, memory.ErrDuplicateEventID) {
+			writeError(c, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, event)
+}
+
+func (h eventsHandler) list(c *gin.Context) {
+	var req listEventsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		writeError(c, http.StatusBadRequest, "tenant_id and session_id are required")
+		return
+	}
+
+	events := h.store.ListBySession(req.TenantID, req.SessionID)
+	c.JSON(http.StatusOK, events)
+}
+
+func writeError(c *gin.Context, status int, message string) {
+	c.JSON(status, gin.H{"error": message})
+}

--- a/internal/httpserver/events_test.go
+++ b/internal/httpserver/events_test.go
@@ -1,0 +1,182 @@
+package httpserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"memplane/internal/memory"
+)
+
+func TestCreateEventSuccess(t *testing.T) {
+	router := newTestRouter(t)
+
+	body := `{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":0,"end_token_exclusive":10,"created_at":"2026-02-10T12:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, rec.Code)
+	}
+
+	var event memory.Event
+	if err := json.Unmarshal(rec.Body.Bytes(), &event); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if event.EventID != "evt_1" {
+		t.Fatalf("expected event id %q, got %q", "evt_1", event.EventID)
+	}
+}
+
+func TestCreateEventRejectsDuplicate(t *testing.T) {
+	router := newTestRouter(t)
+
+	body := `{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":0,"end_token_exclusive":10,"created_at":"2026-02-10T12:00:00Z"}`
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		if i == 0 && rec.Code != http.StatusCreated {
+			t.Fatalf("expected first status %d, got %d", http.StatusCreated, rec.Code)
+		}
+		if i == 1 && rec.Code != http.StatusConflict {
+			t.Fatalf("expected second status %d, got %d", http.StatusConflict, rec.Code)
+		}
+	}
+}
+
+func TestCreateEventRejectsUnknownField(t *testing.T) {
+	router := newTestRouter(t)
+
+	body := `{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":0,"end_token_exclusive":10,"created_at":"2026-02-10T12:00:00Z","unexpected":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestCreateEventRejectsInvalidTokenRange(t *testing.T) {
+	router := newTestRouter(t)
+
+	body := `{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":10,"end_token_exclusive":10,"created_at":"2026-02-10T12:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestCreateEventRejectsMissingCreatedAt(t *testing.T) {
+	router := newTestRouter(t)
+
+	body := `{"event_id":"evt_1","tenant_id":"tenant_1","session_id":"session_1","start_token":0,"end_token_exclusive":10}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestListEventsSuccess(t *testing.T) {
+	store := memory.NewStore()
+	router, err := NewRouter("test", store)
+	if err != nil {
+		t.Fatalf("new router: %v", err)
+	}
+
+	base := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	first, err := memory.NewEvent("evt_2", "tenant_1", "session_1", 10, 20, base.Add(time.Second))
+	if err != nil {
+		t.Fatalf("new event: %v", err)
+	}
+	second, err := memory.NewEvent("evt_1", "tenant_1", "session_1", 0, 10, base)
+	if err != nil {
+		t.Fatalf("new event: %v", err)
+	}
+	if err := store.Append(first); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	if err := store.Append(second); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events?tenant_id=tenant_1&session_id=session_1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var events []memory.Event
+	if err := json.Unmarshal(rec.Body.Bytes(), &events); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].EventID != "evt_1" || events[1].EventID != "evt_2" {
+		t.Fatalf("unexpected order: %#v", events)
+	}
+}
+
+func TestListEventsReturnsEmptyArray(t *testing.T) {
+	router := newTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events?tenant_id=tenant_1&session_id=session_1", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]" {
+		t.Fatalf("expected body %q, got %q", "[]", body)
+	}
+}
+
+func TestListEventsRejectsMissingQuery(t *testing.T) {
+	router := newTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func newTestRouter(t *testing.T) http.Handler {
+	t.Helper()
+
+	EnableStrictJSONDecoding()
+
+	router, err := NewRouter("test", memory.NewStore())
+	if err != nil {
+		t.Fatalf("new router: %v", err)
+	}
+
+	return router
+}

--- a/internal/httpserver/json.go
+++ b/internal/httpserver/json.go
@@ -1,0 +1,7 @@
+package httpserver
+
+import "github.com/gin-gonic/gin"
+
+func EnableStrictJSONDecoding() {
+	gin.EnableJsonDecoderDisallowUnknownFields()
+}

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -1,14 +1,22 @@
 package httpserver
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+
+	"memplane/internal/memory"
 
 	"github.com/gin-gonic/gin"
 )
 
-func NewRouter(environment string) (*gin.Engine, error) {
+func NewRouter(environment string, store *memory.Store) (*gin.Engine, error) {
+	if store == nil {
+		return nil, errors.New("memory store is required")
+	}
+
 	gin.SetMode(ginMode(environment))
+
 	router := gin.New()
 	router.Use(gin.Recovery())
 	if err := router.SetTrustedProxies(nil); err != nil {
@@ -17,6 +25,12 @@ func NewRouter(environment string) (*gin.Engine, error) {
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
+
+	eventsHandler := newEventsHandler(store)
+	v1 := router.Group("/v1")
+	v1.POST("/events", eventsHandler.create)
+	v1.GET("/events", eventsHandler.list)
+
 	return router, nil
 }
 

--- a/internal/httpserver/router_test.go
+++ b/internal/httpserver/router_test.go
@@ -4,13 +4,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"memplane/internal/memory"
 )
 
 func TestHealth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	rec := httptest.NewRecorder()
 
-	router, err := NewRouter("test")
+	router, err := NewRouter("test", memory.NewStore())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -23,5 +25,12 @@ func TestHealth(t *testing.T) {
 
 	if body := rec.Body.String(); body != "{\"status\":\"ok\"}" {
 		t.Fatalf("expected body %q, got %q", "{\"status\":\"ok\"}", body)
+	}
+}
+
+func TestNewRouterRequiresStore(t *testing.T) {
+	_, err := NewRouter("test", nil)
+	if err == nil {
+		t.Fatalf("expected error for nil store")
 	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var errDuplicateEventID = errors.New("event_id already exists in tenant session")
+var ErrDuplicateEventID = errors.New("event_id already exists in tenant session")
 
 type Store struct {
 	mu       sync.RWMutex
@@ -48,7 +48,7 @@ func (s *Store) Append(event Event) error {
 	}
 
 	if _, exists := events.byID[event.EventID]; exists {
-		return errDuplicateEventID
+		return ErrDuplicateEventID
 	}
 
 	events.byID[event.EventID] = event

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -53,8 +53,8 @@ func TestStoreRejectsDuplicateEventIDInSession(t *testing.T) {
 		t.Fatalf("append first: %v", err)
 	}
 	err = store.Append(second)
-	if !errors.Is(err, errDuplicateEventID) {
-		t.Fatalf("expected error %v, got %v", errDuplicateEventID, err)
+	if !errors.Is(err, ErrDuplicateEventID) {
+		t.Fatalf("expected error %v, got %v", ErrDuplicateEventID, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR exposes episodic memory primitives via HTTP with strict request handling and production-focused behavior.

## Changes
- Added `POST /v1/events` and `GET /v1/events` routes under `/v1`
- Wired a shared in-memory store into server startup
- Reused `memory.Event` as the POST payload type (removed duplicate request struct)
- Enabled strict JSON decoding to reject unknown fields
- Added explicit router dependency validation (store must be provided)
- Exported duplicate error sentinel for conflict mapping:
  - `memory.ErrDuplicateEventID`

## API behavior
### POST `/v1/events`
- `201` on success (returns created event)
- `400` on invalid JSON/body/domain validation
- `409` on duplicate `event_id` in same tenant/session

### GET `/v1/events?tenant_id=...&session_id=...`
- `200` with ordered events
- `200` with `[]` if no events
- `400` when required query params are missing

## Tests
Added/updated HTTP and memory tests for:
- create success
- duplicate conflict
- unknown field rejection
- list success (ordering)
- list empty response
- missing query validation
- router nil-store validation

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`

## Notes
Scope remains intentionally minimal:
- no persistence layer
- no auth/multitenancy enforcement beyond provided tenant/session IDs
- no extra abstractions beyond current service needs
