### PR TITLE
Add surprise-based boundary detection and tighten ingest request handling

### DIFF
--- a/cmd/memplane/main.go
+++ b/cmd/memplane/main.go
@@ -30,8 +30,6 @@ func run() error {
 		return err
 	}
 
-	httpserver.EnableStrictJSONDecoding()
-
 	logger, err := logging.New(cfg.Environment, cfg.LogLevel)
 	if err != nil {
 		return err

--- a/internal/httpserver/events.go
+++ b/internal/httpserver/events.go
@@ -29,6 +29,11 @@ func (h eventsHandler) create(c *gin.Context) {
 
 	var event memory.Event
 	if err := c.ShouldBindJSON(&event); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(c, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
 		writeError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}

--- a/internal/httpserver/json.go
+++ b/internal/httpserver/json.go
@@ -1,7 +1,15 @@
 package httpserver
 
-import "github.com/gin-gonic/gin"
+import (
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+var strictJSONDecodingOnce sync.Once
 
 func EnableStrictJSONDecoding() {
-	gin.EnableJsonDecoderDisallowUnknownFields()
+	strictJSONDecodingOnce.Do(func() {
+		gin.EnableJsonDecoderDisallowUnknownFields()
+	})
 }

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -15,6 +15,7 @@ func NewRouter(environment string, store *memory.Store) (*gin.Engine, error) {
 		return nil, errors.New("memory store is required")
 	}
 
+	EnableStrictJSONDecoding()
 	gin.SetMode(ginMode(environment))
 
 	router := gin.New()

--- a/internal/memory/boundary.go
+++ b/internal/memory/boundary.go
@@ -1,0 +1,57 @@
+package memory
+
+import "errors"
+
+var (
+	errNegativeSurpriseThreshold = errors.New("surprise threshold must be non-negative")
+	errInvalidMinBoundaryGap     = errors.New("minimum boundary gap must be positive")
+)
+
+func DetectBoundaries(surprise []float64, threshold float64, minBoundaryGap int) ([]int, error) {
+	if threshold < 0 {
+		return nil, errNegativeSurpriseThreshold
+	}
+	if minBoundaryGap <= 0 {
+		return nil, errInvalidMinBoundaryGap
+	}
+	if len(surprise) < 3 {
+		return []int{}, nil
+	}
+
+	boundaries := make([]int, 0)
+	peaks := make([]float64, 0)
+
+	for i := 1; i < len(surprise)-1; i++ {
+		score := surprise[i]
+		if score <= threshold {
+			continue
+		}
+		// Accept only local maxima so boundaries represent transition peaks.
+		if score <= surprise[i-1] || score <= surprise[i+1] {
+			continue
+		}
+
+		// Boundary is the first token after the peak token.
+		boundary := i + 1
+		last := len(boundaries) - 1
+		if last < 0 {
+			boundaries = append(boundaries, boundary)
+			peaks = append(peaks, score)
+			continue
+		}
+
+		if boundary-boundaries[last] >= minBoundaryGap {
+			boundaries = append(boundaries, boundary)
+			peaks = append(peaks, score)
+			continue
+		}
+
+		// If two peaks are too close, keep the stronger one.
+		if score > peaks[last] {
+			boundaries[last] = boundary
+			peaks[last] = score
+		}
+	}
+
+	return boundaries, nil
+}

--- a/internal/memory/boundary_test.go
+++ b/internal/memory/boundary_test.go
@@ -1,0 +1,93 @@
+package memory
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestDetectBoundariesRejectsInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := DetectBoundaries([]float64{0, 1, 0}, -0.1, 1)
+	if !errors.Is(err, errNegativeSurpriseThreshold) {
+		t.Fatalf("expected error %v, got %v", errNegativeSurpriseThreshold, err)
+	}
+
+	_, err = DetectBoundaries([]float64{0, 1, 0}, 0.5, 0)
+	if !errors.Is(err, errInvalidMinBoundaryGap) {
+		t.Fatalf("expected error %v, got %v", errInvalidMinBoundaryGap, err)
+	}
+}
+
+func TestDetectBoundariesHandlesShortInput(t *testing.T) {
+	t.Parallel()
+
+	for _, scores := range [][]float64{{}, {0.5}, {0.1, 0.9}} {
+		got, err := DetectBoundaries(scores, 0.8, 1)
+		if err != nil {
+			t.Fatalf("detect boundaries: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no boundaries for %v, got %v", scores, got)
+		}
+	}
+}
+
+func TestDetectBoundariesDetectsSurprisePeaks(t *testing.T) {
+	t.Parallel()
+
+	scores := []float64{0.05, 0.2, 1.2, 0.1, 0.15, 1.5, 0.2}
+	got, err := DetectBoundaries(scores, 0.8, 1)
+	if err != nil {
+		t.Fatalf("detect boundaries: %v", err)
+	}
+
+	want := []int{3, 6}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected boundaries %v, got %v", want, got)
+	}
+}
+
+func TestDetectBoundariesThresholdIsStrictlyGreater(t *testing.T) {
+	t.Parallel()
+
+	scores := []float64{0.1, 0.5, 0.1}
+	got, err := DetectBoundaries(scores, 0.5, 1)
+	if err != nil {
+		t.Fatalf("detect boundaries: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("expected no boundaries, got %v", got)
+	}
+}
+
+func TestDetectBoundariesPrefersStrongerPeakWithinGap(t *testing.T) {
+	t.Parallel()
+
+	scores := []float64{0.1, 1.1, 0.2, 1.5, 0.1}
+	got, err := DetectBoundaries(scores, 0.8, 3)
+	if err != nil {
+		t.Fatalf("detect boundaries: %v", err)
+	}
+
+	want := []int{4}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected boundaries %v, got %v", want, got)
+	}
+}
+
+func TestDetectBoundariesRejectsPlateauAsPeak(t *testing.T) {
+	t.Parallel()
+
+	scores := []float64{0.1, 1.0, 1.0, 0.1}
+	got, err := DetectBoundaries(scores, 0.8, 1)
+	if err != nil {
+		t.Fatalf("detect boundaries: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Fatalf("expected no boundaries, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a deterministic boundary detection pass for episodic segmentation and hardens HTTP ingest behavior for production safety.

## What changed

### 1) Memory: surprise-based boundary detection
- Added `DetectBoundaries` in:
  - `/Users/iman/Personal/Memplane/internal/memory/boundary.go`
- Inputs:
  - `surprise []float64`
  - `threshold float64`
  - `minBoundaryGap int`
- Behavior:
  - detects strict local maxima above threshold
  - emits boundary index as `peakIndex + 1`
  - enforces minimum gap between boundaries
  - keeps stronger peak when two candidates are too close
  - validates config (non-negative threshold, positive min gap)

### 2) Memory tests
- Added focused tests in:
  - `/Users/iman/Personal/Memplane/internal/memory/boundary_test.go`
- Covers:
  - invalid config
  - short input edge cases
  - multi-peak detection
  - strict threshold behavior
  - stronger-peak replacement within gap
  - plateau rejection (no strict local peak)

### 3) HTTP ingest hardening
- `POST /v1/events` now maps oversized body to `413`:
  - `/Users/iman/Personal/Memplane/internal/httpserver/events.go`
- Added oversized request test:
  - `/Users/iman/Personal/Memplane/internal/httpserver/events_test.go`

### 4) Strict JSON enforcement consistency
- Ensured strict JSON unknown-field rejection is enabled from router path:
  - `/Users/iman/Personal/Memplane/internal/httpserver/router.go`
- Guarded one-time global setup with `sync.Once`:
  - `/Users/iman/Personal/Memplane/internal/httpserver/json.go`
- Removed redundant bootstrap call from:
  - `/Users/iman/Personal/Memplane/cmd/memplane/main.go`

## Why
- Boundary detection is required to convert raw sequence surprise into episodic split points (paper-aligned segmentation primitive).
- HTTP hardening improves correctness and resilience under malformed/oversized input.
- Router-level strict JSON setup avoids accidental drift across entrypoints.

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
(all passing)

## Paper alignment
Implements the first segmentation primitive from the episodic memory approach: use surprise peaks as candidate transition boundaries, with deterministic constraints before later boundary refinement and retrieval stages.
