### PR TITLE
Add `/v1/segment` API with surprise-to-event segmentation, atomic batch store writes, and endpoint hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ List session events:
 curl -i "http://127.0.0.1:8080/v1/events?tenant_id=tenant_1&session_id=session_1"
 ```
 
+Segment from surprise scores:
+
+```bash
+curl -i -X POST http://127.0.0.1:8080/v1/segment \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant_id":"tenant_1","session_id":"session_1","start_token":100,"surprise":[0.05,0.2,1.2,0.1,0.15,1.5,0.2],"threshold":0.8,"min_boundary_gap":1,"created_at":"2026-02-14T12:00:00Z","event_id_prefix":"seg"}'
+```
+
 ## Roadmap
 
 1. Service foundation (done)

--- a/internal/httpserver/events.go
+++ b/internal/httpserver/events.go
@@ -2,7 +2,9 @@ package httpserver
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"time"
 
 	"memplane/internal/memory"
 
@@ -19,22 +21,38 @@ type listEventsRequest struct {
 }
 
 const maxCreateEventBodyBytes int64 = 1 << 20
+const maxSegmentBodyBytes int64 = 1 << 20
+const maxSegmentSurpriseValues = 8192
+
+var (
+	errRequestBodyTooLarge = errors.New("request body too large")
+	errInvalidRequestBody  = errors.New("invalid request body")
+)
+
+type segmentRequest struct {
+	TenantID       string    `json:"tenant_id" binding:"required"`
+	SessionID      string    `json:"session_id" binding:"required"`
+	StartToken     int       `json:"start_token"`
+	Surprise       []float64 `json:"surprise"`
+	Threshold      float64   `json:"threshold"`
+	MinBoundaryGap int       `json:"min_boundary_gap"`
+	CreatedAt      time.Time `json:"created_at"`
+	EventIDPrefix  string    `json:"event_id_prefix"`
+}
+
+type segmentResponse struct {
+	Boundaries []int          `json:"boundaries"`
+	Events     []memory.Event `json:"events"`
+}
 
 func newEventsHandler(store *memory.Store) eventsHandler {
 	return eventsHandler{store: store}
 }
 
 func (h eventsHandler) create(c *gin.Context) {
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxCreateEventBodyBytes)
-
 	var event memory.Event
-	if err := c.ShouldBindJSON(&event); err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			writeError(c, http.StatusRequestEntityTooLarge, "request body too large")
-			return
-		}
-		writeError(c, http.StatusBadRequest, "invalid request body")
+	if err := bindJSONWithLimit(c, &event, maxCreateEventBodyBytes); err != nil {
+		writeError(c, statusForBindError(err), err.Error())
 		return
 	}
 
@@ -63,6 +81,72 @@ func (h eventsHandler) list(c *gin.Context) {
 	c.JSON(http.StatusOK, events)
 }
 
+func (h eventsHandler) segment(c *gin.Context) {
+	var req segmentRequest
+	if err := bindJSONWithLimit(c, &req, maxSegmentBodyBytes); err != nil {
+		writeError(c, statusForBindError(err), err.Error())
+		return
+	}
+
+	req.CreatedAt = req.CreatedAt.UTC()
+	if len(req.Surprise) > maxSegmentSurpriseValues {
+		writeError(
+			c,
+			http.StatusBadRequest,
+			fmt.Sprintf("surprise must contain at most %d values", maxSegmentSurpriseValues),
+		)
+		return
+	}
+
+	events, boundaries, err := memory.BuildEventsFromSurprise(
+		req.TenantID,
+		req.SessionID,
+		req.StartToken,
+		req.Surprise,
+		req.Threshold,
+		req.MinBoundaryGap,
+		req.CreatedAt,
+		req.EventIDPrefix,
+	)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.store.AppendMany(events); err != nil {
+		if errors.Is(err, memory.ErrDuplicateEventID) {
+			writeError(c, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, segmentResponse{
+		Boundaries: boundaries,
+		Events:     events,
+	})
+}
+
 func writeError(c *gin.Context, status int, message string) {
 	c.JSON(status, gin.H{"error": message})
+}
+
+func bindJSONWithLimit(c *gin.Context, dst any, maxBodyBytes int64) error {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBodyBytes)
+	if err := c.ShouldBindJSON(dst); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return errRequestBodyTooLarge
+		}
+		return errInvalidRequestBody
+	}
+	return nil
+}
+
+func statusForBindError(err error) int {
+	if errors.Is(err, errRequestBodyTooLarge) {
+		return http.StatusRequestEntityTooLarge
+	}
+	return http.StatusBadRequest
 }

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -31,6 +31,7 @@ func NewRouter(environment string, store *memory.Store) (*gin.Engine, error) {
 	v1 := router.Group("/v1")
 	v1.POST("/events", eventsHandler.create)
 	v1.GET("/events", eventsHandler.list)
+	v1.POST("/segment", eventsHandler.segment)
 
 	return router, nil
 }

--- a/internal/memory/segment.go
+++ b/internal/memory/segment.go
@@ -1,0 +1,83 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	errSegmentStartTokenNegative   = errors.New("start_token must be non-negative")
+	errSegmentSurpriseRequired     = errors.New("surprise must contain at least one value")
+	errSegmentEventIDPrefixMissing = errors.New("event id prefix is required")
+	errInvalidBoundary             = errors.New("detected boundary is outside valid token range")
+)
+
+func BuildEventsFromSurprise(
+	tenantID string,
+	sessionID string,
+	startToken int,
+	surprise []float64,
+	threshold float64,
+	minBoundaryGap int,
+	createdAt time.Time,
+	eventIDPrefix string,
+) ([]Event, []int, error) {
+	if startToken < 0 {
+		return nil, nil, errSegmentStartTokenNegative
+	}
+	if len(surprise) == 0 {
+		return nil, nil, errSegmentSurpriseRequired
+	}
+	if eventIDPrefix == "" {
+		return nil, nil, errSegmentEventIDPrefixMissing
+	}
+
+	boundariesRelative, err := DetectBoundaries(surprise, threshold, minBoundaryGap)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	endToken := startToken + len(surprise)
+	boundaries := make([]int, len(boundariesRelative))
+	for i, boundary := range boundariesRelative {
+		absoluteBoundary := startToken + boundary
+		if absoluteBoundary <= startToken || absoluteBoundary >= endToken {
+			return nil, nil, errInvalidBoundary
+		}
+		boundaries[i] = absoluteBoundary
+	}
+
+	events := make([]Event, 0, len(boundaries)+1)
+	cursor := startToken
+	for i, boundary := range boundaries {
+		event, err := NewEvent(
+			fmt.Sprintf("%s_%d", eventIDPrefix, i),
+			tenantID,
+			sessionID,
+			cursor,
+			boundary,
+			createdAt,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		events = append(events, event)
+		cursor = boundary
+	}
+
+	event, err := NewEvent(
+		fmt.Sprintf("%s_%d", eventIDPrefix, len(boundaries)),
+		tenantID,
+		sessionID,
+		cursor,
+		endToken,
+		createdAt,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	events = append(events, event)
+
+	return events, boundaries, nil
+}

--- a/internal/memory/segment_test.go
+++ b/internal/memory/segment_test.go
@@ -1,0 +1,106 @@
+package memory
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildEventsFromSurpriseBuildsContiguousEvents(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 2, 14, 12, 0, 0, 0, time.UTC)
+	surprise := []float64{0.05, 0.2, 1.2, 0.1, 0.15, 1.5, 0.2}
+
+	events, boundaries, err := BuildEventsFromSurprise(
+		"tenant_1",
+		"session_1",
+		100,
+		surprise,
+		0.8,
+		1,
+		createdAt,
+		"seg",
+	)
+	if err != nil {
+		t.Fatalf("build events: %v", err)
+	}
+
+	wantBoundaries := []int{103, 106}
+	if !reflect.DeepEqual(boundaries, wantBoundaries) {
+		t.Fatalf("expected boundaries %v, got %v", wantBoundaries, boundaries)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	if events[0].EventID != "seg_0" || events[0].StartToken != 100 || events[0].EndTokenExclusive != 103 {
+		t.Fatalf("unexpected first event: %#v", events[0])
+	}
+	if events[1].EventID != "seg_1" || events[1].StartToken != 103 || events[1].EndTokenExclusive != 106 {
+		t.Fatalf("unexpected second event: %#v", events[1])
+	}
+	if events[2].EventID != "seg_2" || events[2].StartToken != 106 || events[2].EndTokenExclusive != 107 {
+		t.Fatalf("unexpected third event: %#v", events[2])
+	}
+}
+
+func TestBuildEventsFromSurpriseRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 2, 14, 12, 0, 0, 0, time.UTC)
+	validSurprise := []float64{0.1, 1.0, 0.1}
+
+	cases := []struct {
+		name string
+		err  error
+		run  func() error
+	}{
+		{
+			name: "negative start token",
+			err:  errSegmentStartTokenNegative,
+			run: func() error {
+				_, _, err := BuildEventsFromSurprise("tenant_1", "session_1", -1, validSurprise, 0.5, 1, createdAt, "seg")
+				return err
+			},
+		},
+		{
+			name: "missing surprise",
+			err:  errSegmentSurpriseRequired,
+			run: func() error {
+				_, _, err := BuildEventsFromSurprise("tenant_1", "session_1", 0, nil, 0.5, 1, createdAt, "seg")
+				return err
+			},
+		},
+		{
+			name: "missing event prefix",
+			err:  errSegmentEventIDPrefixMissing,
+			run: func() error {
+				_, _, err := BuildEventsFromSurprise("tenant_1", "session_1", 0, validSurprise, 0.5, 1, createdAt, "")
+				return err
+			},
+		},
+		{
+			name: "invalid threshold from detector",
+			err:  errNegativeSurpriseThreshold,
+			run: func() error {
+				_, _, err := BuildEventsFromSurprise("tenant_1", "session_1", 0, validSurprise, -0.1, 1, createdAt, "seg")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.run()
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected error %v, got %v", tc.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR adds
- New `POST /v1/segment` route and handler.
- `BuildEventsFromSurprise(...)` in memory layer:
  - runs boundary detection,
  - converts relative boundaries to absolute token offsets,
  - creates contiguous `Event` records with deterministic IDs.
- Store batch persistence via `AppendMany(...)` with atomic semantics:
  - validates full batch first,
  - rejects duplicates (existing + in-batch),
  - writes only after precheck passes.
- Shared JSON binding/body-limit helper used by `/v1/events` and `/v1/segment`.
- Segment fan-out guard: max allowed surprise values.
- README example for `/v1/segment`.

### Why this design
- Keeps current phase minimal: accepts precomputed surprise (no tokenizer coupling yet).
- Aligns with paper flow: surprise peaks -> boundaries -> episodic segments.
- Prevents partial data corruption on retries/conflicts.
- Reduces handler duplication and improves operational safety.

### Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`