### PR TITLE
Add `/v1/retrieve` anchor-based retrieval with buffer expansion and request guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ curl -i -X POST http://127.0.0.1:8080/v1/segment \
   -d '{"tenant_id":"tenant_1","session_id":"session_1","start_token":100,"surprise":[0.05,0.2,1.2,0.1,0.15,1.5,0.2],"threshold":0.8,"min_boundary_gap":1,"created_at":"2026-02-14T12:00:00Z","event_id_prefix":"seg"}'
 ```
 
+Retrieve around anchor events:
+
+```bash
+curl -i -X POST http://127.0.0.1:8080/v1/retrieve \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant_id":"tenant_1","session_id":"session_1","event_ids":["seg_1"],"top_k":1,"buffer_before":1,"buffer_after":1}'
+```
+
 ## Roadmap
 
 1. Service foundation (done)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Memplane is being built to serve that role for ecosystems such as LangChain and 
 
 ## Project Status
 
-Current phase: episodic event primitives and initial API.
+Current phase: episodic event primitives, surprise-based segmentation, and anchor-based retrieval API.
 
 ## Quick Start
 

--- a/internal/httpserver/events.go
+++ b/internal/httpserver/events.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"memplane/internal/memory"
@@ -20,9 +21,13 @@ type listEventsRequest struct {
 	SessionID string `form:"session_id" binding:"required"`
 }
 
-const maxCreateEventBodyBytes int64 = 1 << 20
-const maxSegmentBodyBytes int64 = 1 << 20
+const maxJSONBodyBytes int64 = 1 << 20
+const maxCreateEventBodyBytes int64 = maxJSONBodyBytes
+const maxSegmentBodyBytes int64 = maxJSONBodyBytes
+const maxRetrieveBodyBytes int64 = maxJSONBodyBytes
 const maxSegmentSurpriseValues = 8192
+const maxRetrieveAnchorEventIDs = 256
+const maxRetrieveTopK = maxRetrieveAnchorEventIDs
 
 var (
 	errRequestBodyTooLarge = errors.New("request body too large")
@@ -43,6 +48,19 @@ type segmentRequest struct {
 type segmentResponse struct {
 	Boundaries []int          `json:"boundaries"`
 	Events     []memory.Event `json:"events"`
+}
+
+type retrieveRequest struct {
+	TenantID     string   `json:"tenant_id" binding:"required"`
+	SessionID    string   `json:"session_id" binding:"required"`
+	EventIDs     []string `json:"event_ids"`
+	TopK         int      `json:"top_k"`
+	BufferBefore int      `json:"buffer_before"`
+	BufferAfter  int      `json:"buffer_after"`
+}
+
+type retrieveResponse struct {
+	Events []memory.Event `json:"events"`
 }
 
 func newEventsHandler(store *memory.Store) eventsHandler {
@@ -126,6 +144,53 @@ func (h eventsHandler) segment(c *gin.Context) {
 		Boundaries: boundaries,
 		Events:     events,
 	})
+}
+
+func (h eventsHandler) retrieve(c *gin.Context) {
+	var req retrieveRequest
+	if err := bindJSONWithLimit(c, &req, maxRetrieveBodyBytes); err != nil {
+		writeError(c, statusForBindError(err), err.Error())
+		return
+	}
+
+	if len(req.EventIDs) == 0 {
+		writeError(c, http.StatusBadRequest, "event_ids must contain at least one event id")
+		return
+	}
+
+	if len(req.EventIDs) > maxRetrieveAnchorEventIDs {
+		writeError(
+			c,
+			http.StatusBadRequest,
+			fmt.Sprintf("event_ids must contain at most %d items", maxRetrieveAnchorEventIDs),
+		)
+		return
+	}
+	if req.TopK > maxRetrieveTopK {
+		writeError(c, http.StatusBadRequest, fmt.Sprintf("top_k must be at most %d", maxRetrieveTopK))
+		return
+	}
+	for _, eventID := range req.EventIDs {
+		if strings.TrimSpace(eventID) == "" {
+			writeError(c, http.StatusBadRequest, "event_ids must not contain empty values")
+			return
+		}
+	}
+
+	events, err := h.store.RetrieveByAnchors(
+		req.TenantID,
+		req.SessionID,
+		req.EventIDs,
+		req.TopK,
+		req.BufferBefore,
+		req.BufferAfter,
+	)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, retrieveResponse{Events: events})
 }
 
 func writeError(c *gin.Context, status int, message string) {

--- a/internal/httpserver/router.go
+++ b/internal/httpserver/router.go
@@ -32,6 +32,7 @@ func NewRouter(environment string, store *memory.Store) (*gin.Engine, error) {
 	v1.POST("/events", eventsHandler.create)
 	v1.GET("/events", eventsHandler.list)
 	v1.POST("/segment", eventsHandler.segment)
+	v1.POST("/retrieve", eventsHandler.retrieve)
 
 	return router, nil
 }


### PR DESCRIPTION
### What This PR Adds
- Adds a new retrieval endpoint: `POST /v1/retrieve`
- Implements memory-layer retrieval via explicit anchor event IDs:
  - `RetrieveByAnchors(tenant_id, session_id, event_ids, top_k, buffer_before, buffer_after)`
- Retrieval behavior:
  - anchors selected in request order
  - `top_k` respected
  - contiguous expansion with before/after buffers
  - overlap de-duplication
  - final response ordered by session event order

### Production Guardrails Included
- Body-size limits for retrieve payloads
- `event_ids` required and capped
- empty/whitespace `event_ids` rejected
- `top_k` must be positive and capped
- buffer values must be non-negative
- defensive store-side `top_k` clamping to avoid large allocations

### Tests Added/Updated
- Memory-layer tests:
  - buffer expansion behavior
  - top_k handling and anchor de-duplication
  - validation failures
- HTTP-layer tests:
  - successful retrieve response
  - invalid request cases (`event_ids`, `top_k`, negative buffers, too many anchors)
- Existing tests continue to pass.

### Docs
- README updated with `/v1/retrieve` usage example.
- Project status text updated to include segmentation + anchor-based retrieval phase.

### Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`

### Notes
This PR intentionally keeps retrieval deterministic and minimal by using explicit anchors.  
Query/embedding-based anchor selection is intentionally left for the next step.