### PR TITLE
Add modularity-based boundary refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Memplane is being built to serve that role for ecosystems such as LangChain and 
 
 ## Project Status
 
-Current phase: episodic event primitives, surprise-based segmentation, and anchor-based retrieval API.
+Current phase: episodic event primitives, surprise-based segmentation with modularity refinement, and anchor-based retrieval API.
 
 ## Quick Start
 
@@ -51,7 +51,7 @@ Segment from surprise scores:
 ```bash
 curl -i -X POST http://127.0.0.1:8080/v1/segment \
   -H 'Content-Type: application/json' \
-  -d '{"tenant_id":"tenant_1","session_id":"session_1","start_token":100,"surprise":[0.05,0.2,1.2,0.1,0.15,1.5,0.2],"threshold":0.8,"min_boundary_gap":1,"created_at":"2026-02-14T12:00:00Z","event_id_prefix":"seg"}'
+  -d '{"tenant_id":"tenant_1","session_id":"session_1","start_token":100,"surprise":[0.05,0.2,1.2,0.1,0.15,1.5,0.2],"key_similarity":[[1,0,0,0,0,0,0],[0,1,0,0,0,0,0],[0,0,1,0,0,0,0],[0,0,0,1,0,0,0],[0,0,0,0,1,0,0],[0,0,0,0,0,1,0],[0,0,0,0,0,0,1]],"threshold":0.8,"min_boundary_gap":1,"created_at":"2026-02-14T12:00:00Z","event_id_prefix":"seg"}'
 ```
 
 Retrieve around anchor events:
@@ -68,9 +68,9 @@ curl -i -X POST http://127.0.0.1:8080/v1/retrieve \
 2. Core episodic event model (done)
 3. In-memory event store (done)
 4. Initial ingest/list API (done)
-5. Surprise-based boundary detection (paper-aligned)
-6. Boundary refinement (paper-aligned)
-7. Two-stage retrieval: similarity + contiguity buffers
+5. Surprise-based boundary detection (paper-aligned, done)
+6. Boundary refinement (paper-aligned, done)
+7. Two-stage retrieval: similarity + contiguity buffers (in progress)
 8. Durable persistence
 9. LangChain and Mastra adapters
 10. Evaluation harness and production hardening

--- a/internal/httpserver/events.go
+++ b/internal/httpserver/events.go
@@ -35,14 +35,15 @@ var (
 )
 
 type segmentRequest struct {
-	TenantID       string    `json:"tenant_id" binding:"required"`
-	SessionID      string    `json:"session_id" binding:"required"`
-	StartToken     int       `json:"start_token"`
-	Surprise       []float64 `json:"surprise"`
-	Threshold      float64   `json:"threshold"`
-	MinBoundaryGap int       `json:"min_boundary_gap"`
-	CreatedAt      time.Time `json:"created_at"`
-	EventIDPrefix  string    `json:"event_id_prefix"`
+	TenantID       string      `json:"tenant_id" binding:"required"`
+	SessionID      string      `json:"session_id" binding:"required"`
+	StartToken     int         `json:"start_token"`
+	Surprise       []float64   `json:"surprise"`
+	KeySimilarity  [][]float64 `json:"key_similarity" binding:"required"`
+	Threshold      float64     `json:"threshold"`
+	MinBoundaryGap int         `json:"min_boundary_gap"`
+	CreatedAt      time.Time   `json:"created_at"`
+	EventIDPrefix  string      `json:"event_id_prefix"`
 }
 
 type segmentResponse struct {
@@ -121,6 +122,7 @@ func (h eventsHandler) segment(c *gin.Context) {
 		req.SessionID,
 		req.StartToken,
 		req.Surprise,
+		req.KeySimilarity,
 		req.Threshold,
 		req.MinBoundaryGap,
 		req.CreatedAt,

--- a/internal/memory/refine.go
+++ b/internal/memory/refine.go
@@ -1,0 +1,187 @@
+package memory
+
+import (
+	"errors"
+	"math"
+)
+
+var (
+	errRefineSimilarityEmpty          = errors.New("key_similarity is required")
+	errRefineSimilarityNotSquare      = errors.New("key_similarity must be a square matrix")
+	errRefineSimilarityAsymmetric     = errors.New("key_similarity must be symmetric")
+	errRefineSimilarityNegative       = errors.New("key_similarity must have non-negative weights")
+	errRefineSimilarityNonFinite      = errors.New("key_similarity must not contain NaN or Inf")
+	errRefineBoundaryOutOfRange       = errors.New("boundary is outside valid token range")
+	errRefineBoundaryOrderInvalid     = errors.New("boundaries must be strictly increasing")
+	errRefineBoundaryGapInvalid       = errors.New("boundaries violate minimum boundary gap")
+	errRefineNonPositiveTotalAffinity = errors.New("key_similarity has non-positive total affinity")
+)
+
+const similarityTolerance = 1e-9
+
+func RefineBoundariesByModularity(
+	initialBoundaries []int,
+	keySimilarity [][]float64,
+	minBoundaryGap int,
+) ([]int, error) {
+	if minBoundaryGap <= 0 {
+		return nil, errInvalidMinBoundaryGap
+	}
+	if len(keySimilarity) == 0 {
+		return nil, errRefineSimilarityEmpty
+	}
+	tokenCount := len(keySimilarity)
+	for _, row := range keySimilarity {
+		if len(row) != tokenCount {
+			return nil, errRefineSimilarityNotSquare
+		}
+	}
+	if err := validateSimilarityMatrix(keySimilarity); err != nil {
+		return nil, err
+	}
+	if len(initialBoundaries) == 0 {
+		return []int{}, nil
+	}
+	if err := validateBoundaries(initialBoundaries, tokenCount, minBoundaryGap); err != nil {
+		return nil, err
+	}
+
+	refined := make([]int, 0, len(initialBoundaries))
+	for i, boundary := range initialBoundaries {
+		alpha := 0
+		if i > 0 {
+			alpha = refined[i-1]
+		}
+		beta := tokenCount
+		if i+1 < len(initialBoundaries) {
+			beta = initialBoundaries[i+1]
+		}
+
+		candidateMin := alpha + minBoundaryGap
+		candidateMax := beta - minBoundaryGap
+		if candidateMin > candidateMax {
+			return nil, errRefineBoundaryGapInvalid
+		}
+
+		bestBoundary := boundary
+		if bestBoundary < candidateMin {
+			bestBoundary = candidateMin
+		}
+		if bestBoundary > candidateMax {
+			bestBoundary = candidateMax
+		}
+
+		stats, err := buildIntervalStats(keySimilarity, alpha, beta)
+		if err != nil {
+			return nil, err
+		}
+
+		bestScore, err := splitModularityScore(keySimilarity, stats, bestBoundary)
+		if err != nil {
+			return nil, err
+		}
+
+		for candidate := candidateMin; candidate <= candidateMax; candidate++ {
+			score, err := splitModularityScore(keySimilarity, stats, candidate)
+			if err != nil {
+				return nil, err
+			}
+			if score > bestScore {
+				bestScore = score
+				bestBoundary = candidate
+			}
+		}
+
+		refined = append(refined, bestBoundary)
+	}
+
+	return refined, nil
+}
+
+func validateBoundaries(boundaries []int, tokenCount, minBoundaryGap int) error {
+	prev := 0
+	for i, boundary := range boundaries {
+		if boundary <= 0 || boundary >= tokenCount {
+			return errRefineBoundaryOutOfRange
+		}
+		if i > 0 {
+			if boundary <= prev {
+				return errRefineBoundaryOrderInvalid
+			}
+			if boundary-prev < minBoundaryGap {
+				return errRefineBoundaryGapInvalid
+			}
+		}
+		prev = boundary
+	}
+	return nil
+}
+
+func validateSimilarityMatrix(keySimilarity [][]float64) error {
+	for i, row := range keySimilarity {
+		for j := i; j < len(row); j++ {
+			left := row[j]
+			right := keySimilarity[j][i]
+
+			if math.IsNaN(left) || math.IsInf(left, 0) || math.IsNaN(right) || math.IsInf(right, 0) {
+				return errRefineSimilarityNonFinite
+			}
+			if left < -similarityTolerance || right < -similarityTolerance {
+				return errRefineSimilarityNegative
+			}
+			if math.Abs(left-right) > similarityTolerance {
+				return errRefineSimilarityAsymmetric
+			}
+		}
+	}
+	return nil
+}
+
+type intervalStats struct {
+	alpha         int
+	beta          int
+	degree        []float64
+	totalAffinity float64
+}
+
+func buildIntervalStats(keySimilarity [][]float64, alpha, beta int) (intervalStats, error) {
+	degree := make([]float64, beta-alpha)
+	totalAffinity := 0.0
+	for i := alpha; i < beta; i++ {
+		for j := alpha; j < beta; j++ {
+			w := keySimilarity[i][j]
+			degree[i-alpha] += w
+			totalAffinity += w
+		}
+	}
+	if totalAffinity <= 0 {
+		return intervalStats{}, errRefineNonPositiveTotalAffinity
+	}
+
+	return intervalStats{
+		alpha:         alpha,
+		beta:          beta,
+		degree:        degree,
+		totalAffinity: totalAffinity,
+	}, nil
+}
+
+func splitModularityScore(keySimilarity [][]float64, stats intervalStats, split int) (float64, error) {
+	if split <= stats.alpha || split >= stats.beta {
+		return math.Inf(-1), nil
+	}
+
+	modularity := 0.0
+	for i := stats.alpha; i < stats.beta; i++ {
+		for j := stats.alpha; j < stats.beta; j++ {
+			sameCluster := (i < split && j < split) || (i >= split && j >= split)
+			if !sameCluster {
+				continue
+			}
+			expected := (stats.degree[i-stats.alpha] * stats.degree[j-stats.alpha]) / stats.totalAffinity
+			modularity += keySimilarity[i][j] - expected
+		}
+	}
+
+	return modularity / stats.totalAffinity, nil
+}

--- a/internal/memory/refine_test.go
+++ b/internal/memory/refine_test.go
@@ -1,0 +1,61 @@
+package memory
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestRefineBoundariesByModularityRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := RefineBoundariesByModularity([]int{2}, nil, 1)
+	if !errors.Is(err, errRefineSimilarityEmpty) {
+		t.Fatalf("expected error %v, got %v", errRefineSimilarityEmpty, err)
+	}
+
+	_, err = RefineBoundariesByModularity([]int{2}, [][]float64{{1, 0}, {0}}, 1)
+	if !errors.Is(err, errRefineSimilarityNotSquare) {
+		t.Fatalf("expected error %v, got %v", errRefineSimilarityNotSquare, err)
+	}
+
+	_, err = RefineBoundariesByModularity([]int{2}, [][]float64{{1, 0.2}, {0.1, 1}}, 1)
+	if !errors.Is(err, errRefineSimilarityAsymmetric) {
+		t.Fatalf("expected error %v, got %v", errRefineSimilarityAsymmetric, err)
+	}
+
+	_, err = RefineBoundariesByModularity([]int{2}, [][]float64{{1, -0.1}, {-0.1, 1}}, 1)
+	if !errors.Is(err, errRefineSimilarityNegative) {
+		t.Fatalf("expected error %v, got %v", errRefineSimilarityNegative, err)
+	}
+
+	_, err = RefineBoundariesByModularity([]int{2}, [][]float64{{1, math.NaN()}, {math.NaN(), 1}}, 1)
+	if !errors.Is(err, errRefineSimilarityNonFinite) {
+		t.Fatalf("expected error %v, got %v", errRefineSimilarityNonFinite, err)
+	}
+}
+
+func TestRefineBoundariesByModularityShiftsBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Best split should be at boundary 2 for this affinity structure.
+	keySimilarity := [][]float64{
+		{1, 4, 0.1, 0.1, 0.1, 0.1},
+		{4, 1, 0.1, 0.1, 0.1, 0.1},
+		{0.1, 0.1, 1, 4, 4, 4},
+		{0.1, 0.1, 4, 1, 4, 4},
+		{0.1, 0.1, 4, 4, 1, 4},
+		{0.1, 0.1, 4, 4, 4, 1},
+	}
+
+	refined, err := RefineBoundariesByModularity([]int{3}, keySimilarity, 1)
+	if err != nil {
+		t.Fatalf("refine boundaries: %v", err)
+	}
+
+	want := []int{2}
+	if !reflect.DeepEqual(refined, want) {
+		t.Fatalf("expected refined boundaries %v, got %v", want, refined)
+	}
+}


### PR DESCRIPTION
## Summary
This PR makes segmentation paper-aligned by requiring `key_similarity` and refining surprise-based boundaries using modularity optimization before event construction.

## What changed

### Memory layer
- Added `RefineBoundariesByModularity(...)` in `internal/memory/refine.go`.
- Added strict matrix validation:
  - required / non-empty
  - square
  - symmetric (with tolerance)
  - non-negative
  - finite values only (no NaN/Inf)
- Added boundary validation:
  - in-range
  - strictly increasing
  - respects `min_boundary_gap`
- Updated `internal/memory/segment.go`:
  - `BuildEventsFromSurprise(...)` now requires `keySimilarity [][]float64`
  - enforces `len(key_similarity) == len(surprise)`
  - always runs refinement after initial boundary detection

### HTTP/API layer
- Updated `internal/httpserver/events.go`:
  - `segmentRequest` now requires `key_similarity`
  - `/v1/segment` passes `key_similarity` into memory segmentation flow

### Tests
- Added `internal/memory/refine_test.go` for refinement behavior and invalid inputs.
- Updated `internal/memory/segment_test.go` for new required input and refined boundary expectations.
- Updated `internal/httpserver/events_test.go`:
  - success path includes `key_similarity`
  - rejects missing `key_similarity`
  - rejects invalid (non-square) matrix
  - verifies refinement effect via API

### Docs
- Updated `README.md`:
  - segment example now includes required `key_similarity`
  - status/roadmap wording updated to reflect refinement progress

## Behavioral impact
- `POST /v1/segment` now returns `400` if `key_similarity` is missing or invalid.
- Boundary outputs may differ from prior behavior because refinement is now part of the default segmentation path.

## Validation
- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go test -count=1 -shuffle=on ./...`
